### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,15 @@ Mostly Harmless
     :target: http://badge.fury.io/gh/propertyshelf%2Fps.plone.realestatefont
     :alt: Fury Github
 
-.. image:: https://pypip.in/d/ps.plone.realestatefont/badge.png
+.. image:: https://img.shields.io/pypi/dm/ps.plone.realestatefont.svg
     :target: https://pypi.python.org/pypi/ps.plone.realestatefont/
     :alt: Downloads
 
-.. image:: https://pypip.in/v/ps.plone.realestatefont/badge.png
+.. image:: https://img.shields.io/pypi/v/ps.plone.realestatefont.svg
     :target: https://pypi.python.org/pypi/ps.plone.realestatefont/
     :alt: Latest Version
 
-.. image:: https://pypip.in/wheel/ps.plone.realestatefont/badge.png
+.. image:: https://img.shields.io/pypi/wheel/ps.plone.realestatefont.svg
     :target: https://pypi.python.org/pypi/ps.plone.realestatefont/
     :alt: Wheel Status
 
@@ -45,7 +45,7 @@ Mostly Harmless
     :target: https://pypi.python.org/pypi/ps.plone.realestatefont/
     :alt: Egg Status
 
-.. image:: https://pypip.in/license/ps.plone.realestatefont/badge.png
+.. image:: https://img.shields.io/pypi/l/ps.plone.realestatefont.svg
     :target: https://pypi.python.org/pypi/ps.plone.realestatefont/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ps-plone-realestatefont))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ps-plone-realestatefont`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.